### PR TITLE
Do not supply a default Windows MSI checksum

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,7 @@ platforms:
       box_url: http://vagrantboxes.hq.daptiv.com/vagrant/boxes/virtualbox_ubuntu-14.04_chef-12.4.1_1.0.7.box
   - name: windows2012r2
     driver:
-      box: daptiv/windows2012r2_chef11
+      box: daptiv/windows2012r2_chef12
     driver_config:
       communicator: winrm
     transport:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,3 @@ default['google-chrome']['track'] = 'stable'
 default['google-chrome']['windows']['package_name'] = 'Google Chrome'
 default['google-chrome']['windows']['url'] =
   'http://dl.google.com/edgedl/chrome/install/googlechromestandaloneenterprise64.msi'
-
-default['google-chrome']['windows']['checksum'] =
-  '92f77fd6f9d009845f7b976603655cbeb458e8056dda23749f3d1824e901f032'


### PR DESCRIPTION
@heathsnow This allows the cookbook to autofloat the latest release of Chrome without needing to update the checksum attribute.