### PR TITLE
chore: add deprecation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Installs Google Chrome for Windows, Fedora Ubuntu
 
+# DEPRECATION
+
+This cookbook is deprecated.
+
 # Requirements
 
 # Usage


### PR DESCRIPTION
- Deprecating cookbook.  The only remaining consumer was 'our-boxen', which @dachew says is no longer used.